### PR TITLE
 63 - SPanel Implementation

### DIFF
--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -16,6 +16,7 @@ use Upmind\ProvisionProviders\SharedHosting\Enhance\Provider as Enhance;
 use Upmind\ProvisionProviders\SharedHosting\InterWorx\Provider as InterWorx;
 use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Provider as DirectAdmin;
 use Upmind\ProvisionProviders\SharedHosting\CentosWeb\Provider as CentosWeb;
+use Upmind\ProvisionProviders\SharedHosting\SPanel\Provider as SPanel;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -34,5 +35,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('shared-hosting', 'solidcp', SolidCP::class);
         $this->bindProvider('shared-hosting', 'direct-admin', DirectAdmin::class);
         $this->bindProvider('shared-hosting', 'centos-web', CentosWeb::class);
+        $this->bindProvider('shared-hosting', 'spanel', SPanel::class);
     }
 }

--- a/src/SPanel/Api.php
+++ b/src/SPanel/Api.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Arr;
 use GuzzleHttp\Client;
 use Throwable;
 use Carbon\Carbon;
-use Psr\Log\LoggerInterface;
 use GuzzleHttp\HandlerStack;
 use Upmind\ProvisionBase\Helper;
 use Illuminate\Support\Str;
@@ -22,14 +21,11 @@ use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 class Api
 {
     private Configuration $configuration;
-    private ?LoggerInterface $logger;
     protected Client $client;
 
-    public function __construct(Configuration $configuration, ?LoggerInterface $logger = null, ?HandlerStack $handler = null)
+    public function __construct(Configuration $configuration, ?HandlerStack $handler = null)
     {
         $this->configuration = $configuration;
-        $this->logger = $logger;
-
         $this->client = new Client([
             'base_uri' => sprintf('https://%s', $this->configuration->hostname),
             'headers' => [

--- a/src/SPanel/Api.php
+++ b/src/SPanel/Api.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\SPanel;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Arr;
+use GuzzleHttp\Client;
+use Throwable;
+use Carbon\Carbon;
+use Psr\Log\LoggerInterface;
+use GuzzleHttp\HandlerStack;
+use Upmind\ProvisionBase\Helper;
+use Illuminate\Support\Str;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UnitsConsumed;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\SPanel\Data\Configuration;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+
+class Api
+{
+    private Configuration $configuration;
+    private ?LoggerInterface $logger;
+    protected Client $client;
+
+    public function __construct(Configuration $configuration, ?LoggerInterface $logger = null, ?HandlerStack $handler = null)
+    {
+        $this->configuration = $configuration;
+        $this->logger = $logger;
+
+        $this->client = new Client([
+            'base_uri' => sprintf('https://%s', $this->configuration->hostname),
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'http_errors' => true,
+            'allow_redirects' => false,
+            'handler' => $handler,
+        ]);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function makeRequest(
+        ?array  $body = null,
+        ?string $method = 'POST'
+    ): ?array
+    {
+        $requestParams = [];
+
+        $body['token'] = $this->configuration->api_token;
+        $requestParams['form_params'] = $body;
+
+        $response = $this->client->request($method, '/spanel/api.php', $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === '') {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     */
+    private function parseResponseData(string $response): array
+    {
+        $parsedResult = json_decode($response, true);
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    private function getResponseErrorMessage(array $response): ?string
+    {
+        if ($response['result'] == 'error') {
+            if (is_string($response['message'])) {
+                return $response['message'];
+            }
+
+            if (is_array($response['message'])) {
+                return implode(', ', $response['message']);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function createAccount(CreateParams $params, string $username): void
+    {
+        $password = $params->password ?: Helper::generatePassword();
+
+        $body = [
+            'action' => 'accounts/wwwacct',
+            'username' => $username,
+            'password' => $password,
+            'domain' => $params->domain,
+            'package' => $params->package_name,
+            'permissions' => 'all'
+        ];
+
+        $this->makeRequest($body);
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException
+     * @throws Throwable
+     */
+    public function getAccountData(string $username): array
+    {
+        $body = [
+            'action' => 'accounts/listaccounts',
+            'accountuser' => $username,
+        ];
+
+        $response = $this->makeRequest($body);
+        $data = $response['data'][0];
+
+        return [
+            'username' => $data['user'],
+            'domain' => $data['domain'],
+            'reseller' => false,
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => $data['package'],
+            'suspended' => !($data['suspended'] == '0'),
+            'ip' => $data['ip'],
+        ];
+    }
+
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function getAccountUsage(string $username): UsageData
+    {
+        $body = [
+            'action' => 'accounts/listaccounts',
+            'accountuser' => $username,
+        ];
+
+        $response = $this->makeRequest($body);
+        $data = $response['data'][0];
+
+        $disk = UnitsConsumed::create()
+            ->setUsed(isset($data['disk']) ? ((int)$data['disk']) : null)
+            ->setLimit($data['disklimit'] == 'Unlimited' ? null : (int)$data['disklimit']);
+
+        $inodes = UnitsConsumed::create()
+            ->setUsed(isset($data['inodes']) ? ((float)$data['inodes']) : null)
+            ->setLimit($data['inodeslimit'] === 'Unlimited' ? null : $data['inodeslimit']);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setInodes($inodes);
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function updatePackage(string $username, string $packageName): void
+    {
+        $body = [
+            'action' => 'accounts/changequota',
+            'username' => $username,
+            'package' => $packageName,
+        ];
+
+        $this->makeRequest($body);
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function updatePassword(string $username, string $password): void
+    {
+        $body = [
+            'action' => 'accounts/changeuserpassword',
+            'username' => $username,
+            'password' => $password
+        ];
+
+        $this->makeRequest($body);
+    }
+
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function suspendAccount(string $username, ?string $reason): void
+    {
+
+        $body = [
+            'action' => 'accounts/suspendaccount',
+            'username' => $username,
+            'reason' => $reason,
+        ];
+
+        $this->makeRequest($body);
+    }
+
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function unsuspendAccount(string $username): void
+    {
+        $body = [
+            'action' => 'accounts/unsuspendaccount',
+            'username' => $username,
+        ];
+
+        $this->makeRequest($body);
+    }
+
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws \RuntimeException|Throwable
+     */
+    public function deleteAccount(string $username): void
+    {
+        $body = [
+            'action' => 'accounts/terminateaccount',
+            'username' => $username,
+        ];
+
+        $this->makeRequest($body);
+    }
+}

--- a/src/SPanel/Api.php
+++ b/src/SPanel/Api.php
@@ -90,17 +90,27 @@ class Api
 
     private function getResponseErrorMessage(array $response): ?string
     {
-        if ($response['result'] === 'error') {
-            if (is_string($response['message'])) {
-                return $response['message'];
-            }
-
-            if (is_array($response['message'])) {
-                return implode(', ', $response['message']);
-            }
+        // First check if result is set as error, if not, return null.
+        if (!isset($response['result']) || $response['result'] !== 'error') {
+            return null;
         }
 
-        return null;
+        // If message is not set while result is error, return a generic error message.
+        if (!isset($response['message'])) {
+            return 'Unknown error occurred';
+        }
+
+        // Handle different types of message
+        if (is_string($response['message'])) {
+            return $response['message'];
+        }
+
+        if (is_array($response['message'])) {
+            return implode(', ', $response['message']);
+        }
+
+        // Otherwise, return a generic error message.
+        return 'Unknown error occurred';
     }
 
     /**

--- a/src/SPanel/Data/Configuration.php
+++ b/src/SPanel/Data/Configuration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\SPanel\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * SPanel API credentials.
+ * @property-read string $hostname SPanel server hostname
+ * @property-read string $api_token SPanel API token
+ * @property-read string $username SPanel username
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'hostname' => ['required', 'domain_name'],
+            'username' => ['required', 'string'],
+            'api_token' => ['required', 'string']
+        ]);
+    }
+}

--- a/src/SPanel/Provider.php
+++ b/src/SPanel/Provider.php
@@ -292,6 +292,6 @@ class Provider extends Category implements ProviderInterface
             return $this->api;
         }
 
-        return $this->api = new Api($this->configuration, $this->getLogger(), $this->getGuzzleHandlerStack());
+        return $this->api = new Api($this->configuration, $this->getGuzzleHandlerStack());
     }
 }

--- a/src/SPanel/Provider.php
+++ b/src/SPanel/Provider.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\SPanel;
+
+use GuzzleHttp\Exception\ClientException;
+use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\SharedHosting\Category;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsage;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsername;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePasswordParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\EmptyResult;
+use Upmind\ProvisionProviders\SharedHosting\Data\GetLoginUrlParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\GrantResellerParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\LoginUrl;
+use Upmind\ProvisionProviders\SharedHosting\Data\ResellerPrivileges;
+use Upmind\ProvisionProviders\SharedHosting\Data\SuspendParams;
+use Upmind\ProvisionProviders\SharedHosting\SPanel\Data\Configuration;
+
+/**
+ * SPanel provision provider.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * @var Api|null
+     */
+    protected $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('SPanel')
+            ->setDescription('Create and manage SPanel accounts and resellers using the SPanel API')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/spanel-logo.png');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(CreateParams $params): AccountInfo
+    {
+        if (!$params->domain) {
+            $this->errorResult('Domain name is required');
+        }
+
+        $username = $params->username ?? $this->generateUsername($params->domain);
+
+        try {
+            $this->api()->createAccount($params, $username);
+
+            return $this->_getInfo($params->username, 'Account created');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function generateUsername(string $base): string
+    {
+        return substr(
+            preg_replace('/^[^a-z]+/', '', preg_replace('/[^a-z0-9]/', '', strtolower($base))),
+            0,
+            $this->getMaxUsernameLength()
+        );
+    }
+
+    protected function getMaxUsernameLength(): int
+    {
+        return 16;
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    protected function _getInfo(string $username, string $message): AccountInfo
+    {
+        $info = $this->api()->getAccountData($username);
+
+        return AccountInfo::create($info)->setMessage($message);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getInfo(AccountUsername $params): AccountInfo
+    {
+        try {
+            return $this->_getInfo($params->username, 'Account info retrieved');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getUsage(AccountUsername $params): AccountUsage
+    {
+        try {
+            $usage = $this->api()->getAccountUsage($params->username);
+
+            return AccountUsage::create()
+                ->setUsageData($usage);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
+    {
+        return LoginUrl::create()
+            ->setLoginUrl(sprintf('https://%s/spanel/login', $this->configuration->hostname));
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePassword(ChangePasswordParams $params): EmptyResult
+    {
+        try {
+            if (!$this->isValidPassword($params->password)) {
+                $this->errorResult('The password must be at least 8 characters long and contain at least one letter and one number.');
+            }
+
+            $this->api()->updatePassword($params->username, $params->password);
+
+            return $this->emptyResult('Password changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    function isValidPassword($password)
+    {
+        if (strlen($password) >= 8 && preg_match('/[a-zA-Z]/', $password) && preg_match('/\d/', $password)) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePackage(ChangePackageParams $params): AccountInfo
+    {
+        try {
+            $this->api()->updatePackage($params->username, $params->package_name);
+
+            return $this->_getInfo(
+                $params->username,
+                'Package changed'
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function suspend(SuspendParams $params): AccountInfo
+    {
+        try {
+            $this->api()->suspendAccount($params->username, $params->reason ?? null);
+
+            return $this->_getInfo($params->username, 'Account suspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function unSuspend(AccountUsername $params): AccountInfo
+    {
+        try {
+            $this->api()->unsuspendAccount($params->username);
+
+            return $this->_getInfo($params->username, 'Account unsuspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function terminate(AccountUsername $params): EmptyResult
+    {
+        try {
+            $this->api()->deleteAccount($params->username);
+
+            return $this->emptyResult('Account deleted');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function grantReseller(GrantResellerParams $params): ResellerPrivileges
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function revokeReseller(AccountUsername $params): ResellerPrivileges
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function handleException(Throwable $e, array $data = [], array $debug = [], ?string $message = null): void
+    {
+        if ($e instanceof ProvisionFunctionError) {
+            throw $e->withData(
+                array_merge($e->getData(), $data)
+            )->withDebug(
+                array_merge($e->getDebug(), $debug)
+            );
+        }
+
+        // let the provision system handle this one
+        throw $e;
+    }
+
+    protected function api(): Api
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        return $this->api = new Api($this->configuration, $this->getLogger(), $this->getGuzzleHandlerStack());
+    }
+}

--- a/src/SPanel/Provider.php
+++ b/src/SPanel/Provider.php
@@ -163,17 +163,6 @@ class Provider extends Category implements ProviderInterface
         }
     }
 
-
-    function isValidPassword($password)
-    {
-        if (strlen($password) >= 8 && preg_match('/[a-zA-Z]/', $password) && preg_match('/\d/', $password)) {
-            return true;
-        }
-
-        return false;
-    }
-
-
     /**
      * @inheritDoc
      *
@@ -289,5 +278,10 @@ class Provider extends Category implements ProviderInterface
         }
 
         return $this->api;
+    }
+
+    private function isValidPassword($password): bool
+    {
+        return strlen($password) >= 8 && preg_match('/[a-zA-Z]/', $password) && preg_match('/\d/', $password);
     }
 }

--- a/src/SPanel/Provider.php
+++ b/src/SPanel/Provider.php
@@ -96,7 +96,7 @@ class Provider extends Category implements ProviderInterface
      * @throws \RuntimeException
      * @throws \Throwable
      */
-    protected function _getInfo(?string $username, string $message): AccountInfo
+    protected function _getInfo(string $username, string $message): AccountInfo
     {
         $info = $this->api()->getAccountData($username);
 


### PR DESCRIPTION
Closes #63 

Implementation for SPanel based on original PR #61 

Branched off to new branch and make necessary fixes as described in the comments https://github.com/upmind/provision-provider-shared-hosting/pull/61#pullrequestreview-2532927417

Tested all methods as described in the original PR
```
The following operations are implemented for SPanel:

create()
getInfo()
getUsage()
getLoginUrl() - returns a link to https://hostname/spanel/login
changePassword()
changePackage()
suspend()
unSuspend()
terminate()

The following operations aren't supported by SPanel:

grantReseller()
revokeReseller()
```

## Important
Once approved and merged, delete the branch `feature/63-spanel` of the original PR