### PR TITLE
69 - Webuzo provider implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "upmind/enhance-sdk": "^10",
         "giggsey/libphonenumber-for-php-lite": "^8",
         "ext-curl": "*",
+        "ext-json": "*",
         "ext-soap": "*"
     },
     "require-dev": {

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -16,6 +16,7 @@ use Upmind\ProvisionProviders\SharedHosting\Enhance\Provider as Enhance;
 use Upmind\ProvisionProviders\SharedHosting\InterWorx\Provider as InterWorx;
 use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Provider as DirectAdmin;
 use Upmind\ProvisionProviders\SharedHosting\CentosWeb\Provider as CentosWeb;
+use Upmind\ProvisionProviders\SharedHosting\Webuzo\Provider as Webuzo;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -34,5 +35,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('shared-hosting', 'solidcp', SolidCP::class);
         $this->bindProvider('shared-hosting', 'direct-admin', DirectAdmin::class);
         $this->bindProvider('shared-hosting', 'centos-web', CentosWeb::class);
+        $this->bindProvider('shared-hosting', 'webuzo', Webuzo::class);
     }
 }

--- a/src/Webuzo/Api.php
+++ b/src/Webuzo/Api.php
@@ -74,7 +74,14 @@ class Api
      */
     private function parseResponseData(string $response): array
     {
-        $parsedResult = json_decode($response, true);
+        try {
+            $parsedResult = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ProvisionFunctionError::create('Failed to parse response data', $e)
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
 
         if ($error = $this->getResponseErrorMessage($parsedResult)) {
             throw ProvisionFunctionError::create($error)

--- a/src/Webuzo/Api.php
+++ b/src/Webuzo/Api.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\Webuzo;
+
+use Illuminate\Support\Arr;
+use Upmind\ProvisionBase\Helper;
+use GuzzleHttp\Client;
+use RuntimeException;
+use Illuminate\Support\Str;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UnitsConsumed;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\Webuzo\Data\Configuration;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+
+class Api
+{
+    private Configuration $configuration;
+
+    protected Client $client;
+
+    public function __construct(Client $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function makeRequest(
+        string  $command,
+        ?array  $body = null,
+        ?string $method = 'POST'
+    ): ?array
+    {
+        $requestParams = [];
+
+        if ($command == 'sso') {
+            $requestParams['query']['loginAs'] = $body['username'];
+            $requestParams['query']['noip'] = 1;
+        }
+
+        $requestParams['query']['api'] = 'json';
+        $requestParams['query']['act'] = $command;
+
+        if ($body) {
+            $requestParams['form_params'] = $body;
+        }
+
+        if (isset($this->configuration->api_key)) {
+            $requestParams['form_params']['apikey'] = $this->configuration->api_key;
+
+            if (isset($this->configuration->username)) {
+                $requestParams['form_params']['apiuser'] = $this->configuration->username;
+            } else {
+                $requestParams['form_params']['apiuser'] = 'root';
+            }
+        }
+
+        $response = $this->client->request($method, '/index.php', $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === "") {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function parseResponseData(string $response): array
+    {
+        $parsedResult = json_decode($response, true);
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    private function getResponseErrorMessage(array $response): ?string
+    {
+        if (isset($response['error'])) {
+            $message = '';
+            foreach ($response['error'] as $error) {
+                $message .= strip_tags($error) . '; ';
+            }
+            return $message;
+        }
+
+        return null;
+    }
+
+    public function createAccount(CreateParams $params, string $username, bool $asReseller): void
+    {
+        $password = $params->password ?: Helper::generatePassword();
+
+        $body = [
+            'create_user' => 1,
+            'user' => $username,
+            'user_passwd' => $password,
+            'cnf_user_passwd' => $password,
+            'domain' => $params->domain,
+            'email' => $params->email,
+            'plan' => $params->package_name,
+        ];
+
+        $this->makeRequest('add_user', $body);
+
+        if ($asReseller) {
+            $this->setReseller($username, 1);
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function getAccountData(string $username): array
+    {
+        $account = $this->getUserDetails($username);
+
+        return [
+            'username' => $username,
+            'domain' => $account['domain'] ?? null,
+            'reseller' => $account['type'] == 2,
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => $account['plan'] != "" ? $account['plan'] : "Unknown",
+            'suspended' => $account['status'] === 'suspended',
+            'suspend_reason' => $account['suspend_reason'] ?? null,
+            'ip' => $account['ip'] ?? null,
+        ];
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getUserDetails(string $username): ?array
+    {
+        $body = [
+            'search' => $username,
+        ];
+
+        $response = $this->makeRequest('users', $body);
+
+        foreach ($response['users'] as $name => $account) {
+            if ($name === trim($username)) {
+                return $account;
+            }
+        }
+
+        throw ProvisionFunctionError::create("User does not exist")
+            ->withData([
+                'username' => $username,
+            ]);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function getAccountUsage(string $username): UsageData
+    {
+        $account = $this->getUserDetails($username)['resource'];
+
+        $disk = UnitsConsumed::create()
+            ->setUsed((int)$account['disk']['used_bytes'] / (1024 * 1024))
+            ->setLimit(($account['disk']['limit_bytes'] == 0 || $account['disk']['limit_bytes'] == 'unlimited')
+                ? null : (int)$account['disk']['limit_bytes'] / (1024 * 1024));
+
+        $bandwidth = UnitsConsumed::create()
+            ->setUsed((int)$account['bandwidth']['used_bytes'] / (1024 * 1024))
+            ->setLimit(($account['bandwidth']['limit_bytes'] == 0 || $account['bandwidth']['limit_bytes'] == 'unlimited')
+                ? null : (int)$account['bandwidth']['limit_bytes'] / (1024 * 1024));
+
+        $inodes = UnitsConsumed::create()
+            ->setUsed((int)$account['inode']['used'])
+            ->setLimit($account['inode']['limit'] == 'unlimited'
+                ? null : (int)$account['inode']['limit']);
+
+        $mailboxes = UnitsConsumed::create()
+            ->setUsed((int)$account['email_account']['used'])
+            ->setLimit($account['email_account']['limit'] == 'unlimited'
+                ? null : (int)$account['email_account']['limit']);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setBandwidthMb($bandwidth)
+            ->setInodes($inodes)
+            ->setMailboxes($mailboxes);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function suspendAccount(string $username): void
+    {
+        $body = [
+            'suspend' => $username
+        ];
+
+        $this->makeRequest('users', $body);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function unsuspendAccount(string $username): void
+    {
+        $body = [
+            'unsuspend' => $username
+        ];
+
+        $this->makeRequest('users', $body);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function deleteAccount(string $username): void
+    {
+        $body = [
+            'delete_user' => $username
+        ];
+
+        $this->makeRequest('users', $body);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function updatePackage(string $username, string $package): void
+    {
+        $account = $this->getUserDetails($username);
+
+        $body = [
+            'edit_user' => 1,
+            'user' => $username,
+            'user_name' => $username,
+            'domain' => $account['domain'],
+            'email' => $account['email'],
+            'plan' => $package
+        ];
+
+        $this->makeRequest('add_user', $body);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function updatePassword(string $username, string $password): void
+    {
+        $account = $this->getUserDetails($username);
+
+        $body = [
+            'edit_user' => 1,
+            'user' => $username,
+            'user_name' => $username,
+            'domain' => $account['domain'],
+            'email' => $account['email'],
+            'plan' => $account['plan'],
+            'user_passwd' => $password,
+            'cnf_user_passwd' => $password
+        ];
+
+        $this->makeRequest('add_user', $body);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function getLoginUrl(string $username): string
+    {
+        $body = [
+            'username' => $username,
+        ];
+
+        $response = $this->makeRequest('sso', $body);
+
+        return $response['done']['url'];
+    }
+
+    public function setReseller(string $username, int $isReseller)
+    {
+        $account = $this->getUserDetails($username);
+
+        $body = [
+            'edit_user' => 1,
+            'user' => $username,
+            'user_name' => $username,
+            'domain' => $account['domain'],
+            'email' => $account['email'],
+            'plan' => $account['plan'],
+            'reseller' => $isReseller,
+        ];
+
+        $this->makeRequest('add_user', $body);
+    }
+}

--- a/src/Webuzo/Data/Configuration.php
+++ b/src/Webuzo/Data/Configuration.php
@@ -10,9 +10,9 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 /**
  * Webuzo API credentials.
  * @property-read string $hostname API hostname
- * @property-read string $api_key API key
- * @property-read string $username Username
- * @property-read string $password Password
+ * @property-read string|null $api_key API key
+ * @property-read string|null $username Username
+ * @property-read string|null $password Password
  */
 class Configuration extends DataSet
 {

--- a/src/Webuzo/Data/Configuration.php
+++ b/src/Webuzo/Data/Configuration.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\Webuzo\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Webuzo API credentials.
+ * @property-read string $hostname API hostname
+ * @property-read string $api_key API key
+ * @property-read string $username Username
+ * @property-read string $password Password
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'hostname' => ['required', 'string'],
+            'api_key' => ['required_without_all:username,password', 'nullable', 'string'],
+            'username' => ['required_without:api_key', 'nullable', 'string'],
+            'password' => ['required_without:api_key', 'nullable', 'string'],
+        ]);
+    }
+}

--- a/src/Webuzo/Provider.php
+++ b/src/Webuzo/Provider.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Upmind\ProvisionProviders\SharedHosting\Webuzo;
 
 use GuzzleHttp\Client;
-use Carbon\Carbon;
 use Throwable;
-use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\SharedHosting\Category;
@@ -32,15 +30,8 @@ class Provider extends Category implements ProviderInterface
 {
     protected const MAX_USERNAME_LENGTH = 10;
 
-    /**
-     * @var Configuration
-     */
-    protected $configuration;
-
-    /**
-     * @var Api|null
-     */
-    protected $api;
+    protected Configuration $configuration;
+    protected ?Api $api = null;
 
     public function __construct(Configuration $configuration)
     {
@@ -63,7 +54,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function create(CreateParams $params): AccountInfo
     {
@@ -109,7 +99,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function getInfo(AccountUsername $params): AccountInfo
     {
@@ -122,7 +111,6 @@ class Provider extends Category implements ProviderInterface
     /**
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function getUsage(AccountUsername $params): AccountUsage
     {
@@ -137,7 +125,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
     {
@@ -156,7 +143,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function changePassword(ChangePasswordParams $params): EmptyResult
     {
@@ -170,7 +156,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function changePackage(ChangePackageParams $params): AccountInfo
     {
@@ -187,7 +172,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function suspend(SuspendParams $params): AccountInfo
     {
@@ -201,7 +185,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function unSuspend(AccountUsername $params): AccountInfo
     {
@@ -215,7 +198,6 @@ class Provider extends Category implements ProviderInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
      */
     public function terminate(AccountUsername $params): EmptyResult
     {
@@ -227,6 +209,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @inheritDoc
      *
+     * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function grantReseller(GrantResellerParams $params): ResellerPrivileges
@@ -241,6 +224,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @inheritDoc
      *
+     * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function revokeReseller(AccountUsername $params): ResellerPrivileges
@@ -255,6 +239,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @return no-return
      *
+     * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      * @throws \Throwable
      */
@@ -272,7 +257,7 @@ class Provider extends Category implements ProviderInterface
 
         $auth = '';
 
-        if (isset($this->configuration->username) && isset($this->configuration->password)) {
+        if (isset($this->configuration->username, $this->configuration->password)) {
             $auth = $this->configuration->username . ':' . $this->configuration->password . '@';
         }
 

--- a/src/Webuzo/Provider.php
+++ b/src/Webuzo/Provider.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\Webuzo;
+
+use GuzzleHttp\Client;
+use Carbon\Carbon;
+use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\SharedHosting\Category;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsage;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsername;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePasswordParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\EmptyResult;
+use Upmind\ProvisionProviders\SharedHosting\Data\GetLoginUrlParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\GrantResellerParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\LoginUrl;
+use Upmind\ProvisionProviders\SharedHosting\Data\ResellerPrivileges;
+use Upmind\ProvisionProviders\SharedHosting\Data\SuspendParams;
+use Upmind\ProvisionProviders\SharedHosting\Webuzo\Data\Configuration;
+
+/**
+ * Webuzo provision provider.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    protected const MAX_USERNAME_LENGTH = 10;
+
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * @var Api|null
+     */
+    protected $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Webuzo')
+            ->setDescription('Create and manage Webuzo accounts and resellers using the Webuzo API')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/webuzo-logo.png');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(CreateParams $params): AccountInfo
+    {
+        if (!$params->domain) {
+            $this->errorResult('Domain name is required');
+        }
+
+        $asReseller = boolval($params->as_reseller ?? false);
+
+        $username = $params->username ?: $this->generateUsername($params->domain);
+
+        $this->api()->createAccount(
+            $params,
+            $username,
+            $asReseller
+        );
+
+        return $this->_getInfo($username, 'Account created');
+    }
+
+    protected function generateUsername(string $base): string
+    {
+        return substr(
+            preg_replace('/^[^a-z]+/', '', preg_replace('/[^a-z0-9]/', '', strtolower($base))),
+            0,
+            self::MAX_USERNAME_LENGTH
+        );
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    protected function _getInfo(string $username, string $message): AccountInfo
+    {
+        $info = $this->api()->getAccountData($username);
+
+        return AccountInfo::create($info)->setMessage($message);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getInfo(AccountUsername $params): AccountInfo
+    {
+        return $this->_getInfo(
+            $params->username,
+            'Account info retrieved',
+        );
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getUsage(AccountUsername $params): AccountUsage
+    {
+        $usage = $this->api()->getAccountUsage($params->username);
+
+        return AccountUsage::create()
+            ->setUsageData($usage);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
+    {
+        $loginUrl = $this->api()->getLoginUrl($params->username);
+
+        if (str_contains($loginUrl, 'webuzo.whgi.net')) {
+            $loginUrl = str_replace('webuzo.whgi.net', $this->configuration->hostname, $loginUrl);
+        }
+
+        return LoginUrl::create()
+            ->setLoginUrl($loginUrl);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePassword(ChangePasswordParams $params): EmptyResult
+    {
+        $this->api()->updatePassword($params->username, $params->password);
+
+        return $this->emptyResult('Password changed');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePackage(ChangePackageParams $params): AccountInfo
+    {
+        $this->api()->updatePackage($params->username, $params->package_name);
+
+        return $this->_getInfo(
+            $params->username,
+            'Package changed'
+        );
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function suspend(SuspendParams $params): AccountInfo
+    {
+        $this->api()->suspendAccount($params->username);
+
+        return $this->_getInfo($params->username, 'Account suspended');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function unSuspend(AccountUsername $params): AccountInfo
+    {
+        $this->api()->unsuspendAccount($params->username);
+
+        return $this->_getInfo($params->username, 'Account unsuspended');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function terminate(AccountUsername $params): EmptyResult
+    {
+        $this->api()->deleteAccount($params->username);
+
+        return $this->emptyResult('Account deleted');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function grantReseller(GrantResellerParams $params): ResellerPrivileges
+    {
+        $this->api()->setReseller($params->username, 1);
+
+        return ResellerPrivileges::create()
+            ->setMessage('Reseller privileges granted')
+            ->setReseller(true);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function revokeReseller(AccountUsername $params): ResellerPrivileges
+    {
+        $this->api()->setReseller($params->username, 0);
+
+        return ResellerPrivileges::create()
+            ->setMessage('Reseller privileges revoked')
+            ->setReseller(false);
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        // let the provision system handle this one
+        throw $e;
+    }
+
+    protected function api(): Api
+    {
+        if ($this->api) {
+            return $this->api;
+        }
+
+        $auth = '';
+
+        if (isset($this->configuration->username) && isset($this->configuration->password)) {
+            $auth = $this->configuration->username . ':' . $this->configuration->password . '@';
+        }
+
+        $client = new Client([
+            'base_uri' => sprintf('https://%s%s:%s', $auth, $this->configuration->hostname, 2005),
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'verify' => false,
+            'http_errors' => true,
+            'allow_redirects' => false,
+            'handler' => $this->getGuzzleHandlerStack(),
+        ]);
+
+        return $this->api = new Api($client, $this->configuration);
+    }
+}


### PR DESCRIPTION
Closes #69 

Implementation for Webuzo based on original PR #66 

After we addressed the PR review items, made some changes on docblocks and added json exception error handling

Tested all methods as described in the original PR and working as expected (including the `terminate` function)
```
The following operations are implemented for Webuzo:

- create()
- getInfo()
- getUsage()
- getLoginUrl()
- changePassword()
- changePackage()
- suspend()
- unSuspend()
- terminate()
- grantReseller()
- revokeReseller()
```