### PR TITLE
Implement Panelalpha

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-          tools: composer, phpstan
+          tools: composer, phpstan:1
 
       - name: "Get composer cache directory"
         id: composer-cache

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -16,6 +16,7 @@ use Upmind\ProvisionProviders\SharedHosting\Enhance\Provider as Enhance;
 use Upmind\ProvisionProviders\SharedHosting\InterWorx\Provider as InterWorx;
 use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Provider as DirectAdmin;
 use Upmind\ProvisionProviders\SharedHosting\CentosWeb\Provider as CentosWeb;
+use Upmind\ProvisionProviders\SharedHosting\Panelalpha\Provider as Panelalpha;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -34,5 +35,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('shared-hosting', 'solidcp', SolidCP::class);
         $this->bindProvider('shared-hosting', 'direct-admin', DirectAdmin::class);
         $this->bindProvider('shared-hosting', 'centos-web', CentosWeb::class);
+        $this->bindProvider('shared-hosting', 'panel-alpha', Panelalpha::class);
     }
 }

--- a/src/Panelalpha/Api.php
+++ b/src/Panelalpha/Api.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\Panelalpha;
+
+use GuzzleHttp\Client;
+use Upmind\ProvisionBase\Helper;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UnitsConsumed;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\Panelalpha\Data\Configuration;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+
+class Api
+{
+    protected Client $client;
+    private Configuration $configuration;
+
+    public function __construct(Client $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function makeRequest(
+        string  $command,
+        ?array  $body = null,
+        ?string $method = 'GET'
+    ): ?array
+    {
+        $requestParams = [];
+
+        if ($body) {
+            $requestParams['form_params'] = $body;
+        }
+
+        $response = $this->client->request($method, "api/admin/{$command}", $requestParams);
+
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === "") {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function parseResponseData(string $response): array
+    {
+        $parsedResult = json_decode($response, true);
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $parsedResult["data"] ?? [];
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function createAccount(CreateParams $params, string $username): void
+    {
+        $password = $params->password ?: Helper::generatePassword();
+
+        $planId = $params->package_name;
+
+        if (!is_numeric($planId)) {
+            $planId = $this->getPlanID($planId);
+        }
+
+        $query = [
+            "first_name" => $username,
+            "email" => $params->email,
+            "password" => $password,
+        ];
+
+        $userId = $this->makeRequest("users", $query, "POST")["id"];
+
+        $query = [
+            "plan_id" => $planId,
+        ];
+
+        $serviceId = $this->makeRequest("users/{$userId}/services", $query, "POST")["id"];
+
+        $query = [
+            "user_id" => $userId,
+            "service_id" => $serviceId,
+            "name" => $username,
+        ];
+
+        if ($params->domain) {
+            $query["domain"] = $params->domain;
+        }
+
+        $this->makeRequest("instances", $query, "POST");
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getAccountData(string $username, ?string $domain): array
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $account = $this->getUserConfig($username);
+
+        $service = $this->getService($username, $domain);
+
+        return [
+            'username' => $account['name'],
+            'domain' => $service["domain"] ?? null,
+            'reseller' => false,
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => $service["plan_name"] ?? "unknown",
+            'suspended' => isset($service["service"]) && $service["service"]["status"] == "suspended",
+            'suspend_reason' => null,
+            'ip' => $service['host_ip_address'] ?? null,
+            'nameservers' => $service["host_nameservers"] ?? [],
+        ];
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getUserConfig(string $username): array
+    {
+        return $this->makeRequest("users/{$username}");
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getInstances(string $username): array
+    {
+        return $this->makeRequest("users/{$username}/all-instances");
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function suspendAccount(string $username): void
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $services = $this->getServiceIDs($username);
+
+        foreach ($services as $service) {
+            $this->makeRequest("users/$username/services/$service/suspend", null, 'PUT');
+        }
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function unsuspendAccount(string $username): void
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $services = $this->getServiceIDs($username);
+
+        foreach ($services as $service) {
+            $this->makeRequest("users/$username/services/$service/unsuspend", null, 'PUT');
+        }
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getServiceIDs($userId): array
+    {
+        $services = $this->makeRequest("users/$userId/services");
+        $ids = [];
+
+        foreach ($services as $service) {
+            $ids[] = $service['id'];
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getUserID($username)
+    {
+        $users = $this->makeRequest("users");
+        foreach ($users as $user) {
+            if ($user['email'] === $username) {
+                return (string)$user['id'];
+
+            }
+        }
+
+        throw ProvisionFunctionError::create("User does not exist")
+            ->withData([
+                'username' => $username,
+            ]);
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getPlanID($plan)
+    {
+        $plans = $this->makeRequest("plans");
+        foreach ($plans as $p) {
+            if (strtolower($p['name']) === strtolower($plan)) {
+                return (string)$p['id'];
+            }
+        }
+
+        throw ProvisionFunctionError::create("Plan does not exist")
+            ->withData([
+                'plan' => $plan,
+            ]);
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getService($username, $domain)
+    {
+        $services = $this->getInstances($username);
+
+        if (!$domain) {
+            return $services[0];
+        }
+
+        foreach ($services as $s) {
+            if ($s["domain"] == $domain) {
+                return $s;
+            }
+        }
+
+        throw ProvisionFunctionError::create("Domain does not exist")
+            ->withData([
+                'domain' => $domain,
+            ]);
+
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function deleteAccount(string $username): void
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $this->makeRequest("users/$username", null, 'DELETE');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function updatePackage(string $username, string $package_name, string $domain): void
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $service = $this->getService($username, $domain);
+
+        $planId = $package_name;
+
+        if (!is_numeric($planId)) {
+            $planId = $this->getPlanID($planId);
+        }
+
+        $serviceId = $service["service"]["id"];
+        $query = [
+            'plan_id' => $planId,
+        ];
+
+        $this->makeRequest("users/{$username}/services/{$serviceId}/change-plan", $query, "PUT");
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getAccountUsage(string $username, ?string $domain): UsageData
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $service = $this->getService($username, $domain);
+
+        $usage = $service["stats"] ?? null;
+        if (!$usage) {
+            return new UsageData();
+        }
+
+        $disk = UnitsConsumed::create()
+            ->setUsed((int)$usage['storage']["usage"] / 1024 / 1024)
+            ->setLimit($usage['storage']['maximum'] != 0 ? (int)($usage['storage']['maximum'] / 1024 / 1024) : null);
+
+        $bandwidth = UnitsConsumed::create()
+            ->setUsed((int)$usage['bandwidth']["usage"] / 1024 / 1024)
+            ->setLimit($usage['bandwidth']['maximum'] != 0 ? (int)($usage['bandwidth']['maximum'] / 1024 / 1024) : null);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setBandwidthMb($bandwidth);
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getLoginUrl(string $username): string
+    {
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $sso = $this->makeRequest("users/{$username}/sso-token", null, 'POST');
+
+        return "{$sso["url"]}/sso-login?token={$sso["token"]}";
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function updatePassword(string $username, string $password)
+    {
+        $email = $username;
+        if (!is_numeric($username)) {
+            $username = $this->getUserID($username);
+        }
+
+        $query = [
+            'email' => $email,
+            'password' => $password,
+        ];
+
+        $this->makeRequest("users/{$username}", $query, "PUT");
+    }
+
+}

--- a/src/Panelalpha/Data/Configuration.php
+++ b/src/Panelalpha/Data/Configuration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\Panelalpha\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * PanelAlpha API credentials.
+ * @property-read string $hostname PanelAlpha server hostname
+ * @property-read int|null $port PanelAlpha serves port
+ * @property-read string $api_token PanelAlpha API key
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'hostname' => ['required', 'domain_name'],
+            'port' => ['nullable', 'integer'],
+            'api_token' => ['required', 'string']
+        ]);
+    }
+}

--- a/src/Panelalpha/Provider.php
+++ b/src/Panelalpha/Provider.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\Panelalpha;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use Throwable;
+use Carbon\Carbon;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\TransferException;
+use Illuminate\Support\Str;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\SharedHosting\Category;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsage;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsername;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePasswordParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\EmptyResult;
+use Upmind\ProvisionProviders\SharedHosting\Data\GetLoginUrlParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\GrantResellerParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\LoginUrl;
+use Upmind\ProvisionProviders\SharedHosting\Data\ResellerPrivileges;
+use Upmind\ProvisionProviders\SharedHosting\Data\SuspendParams;
+use Upmind\ProvisionProviders\SharedHosting\Panelalpha\Data\Configuration;
+
+class Provider extends Category implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected Configuration $configuration;
+    protected const MAX_USERNAME_LENGTH = 10;
+
+    /**
+     * @var Api|null
+     */
+    protected $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Panelalpha')
+            ->setDescription('Create and manage PanelAlpha accounts and resellers using the PanelAlpha API')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/panel-alpha-logo.png');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(CreateParams $params): AccountInfo
+    {
+        $username = $params->username ?: $this->generateUsername($params->domain);
+
+        try {
+            $this->api()->createAccount(
+                $params,
+                $username
+            );
+
+            return $this->_getInfo($username, $params->domain, 'Account created');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function generateUsername(string $base): string
+    {
+        return substr(
+            preg_replace('/^[^a-z]+/', '', preg_replace('/[^a-z0-9]/', '', strtolower($base))),
+            0,
+            self::MAX_USERNAME_LENGTH
+        );
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    protected function _getInfo(string $username, ?string $domain, string $message): AccountInfo
+    {
+        $info = $this->api()->getAccountData($username, $domain);
+
+        return AccountInfo::create($info)->setMessage($message);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getInfo(AccountUsername $params): AccountInfo
+    {
+        try {
+            return $this->_getInfo(
+                $params->username,
+                $params->domain,
+                'Account info retrieved',
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getUsage(AccountUsername $params): AccountUsage
+    {
+        try {
+            $usage = $this->api()->getAccountUsage($params->username, $params->domain);
+
+            return AccountUsage::create()
+                ->setUsageData($usage);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
+    {
+        try {
+            $loginUrl = $this->api()->getLoginUrl($params->username);
+
+            return LoginUrl::create()
+                ->setLoginUrl($loginUrl)
+                ->setExpires(Carbon::now()->addMinutes(30));
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePassword(ChangePasswordParams $params): EmptyResult
+    {
+        try {
+            $this->api()->updatePassword($params->username, $params->password);
+
+            return $this->emptyResult('Password changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePackage(ChangePackageParams $params): AccountInfo
+    {
+        try {
+            if (!$params->domain) {
+                $this->errorResult('Domain is required');
+            }
+
+            $this->api()->updatePackage($params->username, $params->package_name, $params->domain);
+
+            return $this->_getInfo(
+                $params->username,
+                $params->domain,
+                'Package changed'
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function suspend(SuspendParams $params): AccountInfo
+    {
+        try {
+            $this->api()->suspendAccount($params->username);
+
+            return $this->_getInfo($params->username, $params->domain, 'Account suspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function unSuspend(AccountUsername $params): AccountInfo
+    {
+        try {
+            $this->api()->unsuspendAccount($params->username);
+
+            return $this->_getInfo($params->username, $params->domain, 'Account unsuspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function terminate(AccountUsername $params): EmptyResult
+    {
+        try {
+            $this->api()->deleteAccount($params->username);
+
+            return $this->emptyResult('Account deleted');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function grantReseller(GrantResellerParams $params): ResellerPrivileges
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function revokeReseller(AccountUsername $params): ResellerPrivileges
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if (($e instanceof RequestException) && $e->hasResponse()) {
+            /** @var \Psr\Http\Message\ResponseInterface $response */
+            $response = $e->getResponse();
+
+            $body = trim($response->getBody()->__toString());
+            $responseData = json_decode($body, true);
+
+            $errorMessage = $responseData['message'] ?? 'unknown error';
+
+
+            $this->errorResult(
+                sprintf('Provider API Error: %s', $errorMessage),
+                ['response_data' => $responseData],
+                [],
+                $e
+            );
+        }
+
+        // Throw the exception if it's not a RequestException
+        throw $e;
+    }
+
+    protected function api(): Api
+    {
+        if ($this->api) {
+            return $this->api;
+        }
+
+        $client = new Client([
+            'base_uri' => sprintf('https://%s:%s', $this->configuration->hostname, $this->configuration->port),
+            'headers' => [
+                'Authorization' => 'Bearer ' . $this->configuration->api_token,
+                'Accept' => 'application/json',
+            ],
+            'verify' => false,
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'http_errors' => true,
+            'allow_redirects' => false,
+            'handler' => $this->getGuzzleHandlerStack(),
+        ]);
+
+        return $this->api = new Api($client, $this->configuration);
+    }
+}


### PR DESCRIPTION
The following operations are implemented for PanelAlpha:

- create()
- getInfo()
- getUsage()
- getLoginUrl()
- changePassword()
- changePackage()
- suspend()
- unSuspend()
- terminate()

The following operations aren't supported by PanelAlpha:

- grantReseller()
- revokeReseller()

Note that the "username" field must be filled with email or id, since the username is not unique in the PanelAlpha